### PR TITLE
Handle SRV lookup, default to port 25565

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -19,8 +19,9 @@ const (
 )
 
 var (
-	ErrConnectionState = errors.New("connection has invalid state for packet type")
-	ErrDirection       = errors.New("packet being sent in wrong direction")
+	ErrConnectionState  = errors.New("connection has invalid state for packet type")
+	ErrDirection        = errors.New("packet being sent in wrong direction")
+	ErrLegacyServerPing = errors.New("not implemented: legacy server ping")
 )
 
 // Connection represents a connection
@@ -145,7 +146,7 @@ func (c *connection) ReadPacket(ctx context.Context) (packet.Packet, error) {
 
 	// TODO: Maybe handle legacy server ping? (https://wiki.vg/Server_List_Ping#1.6)
 	if length == 0xFE {
-		return nil, fmt.Errorf("not implemented: Legacy server ping")
+		return nil, ErrLegacyServerPing
 	}
 
 	// Catch invalid packet lengths
@@ -169,20 +170,20 @@ func (c *connection) ReadPacket(ctx context.Context) (packet.Packet, error) {
 	}
 
 	// Lookup packet type
-	packet, err := c.getPacketTypeByID(int32(pID))
+	pkt, err := c.getPacketTypeByID(int32(pID))
 
 	if err != nil {
 		return nil, err
 	}
 
-	log.Printf("[Recv] %s, %d: %s\n", c.state, pID, packet.String())
+	log.Printf("[Recv] %s, %d: %s\n", c.state, pID, pkt.String())
 
 	// Decode packet
-	if err = packet.Read(reader); err != nil {
+	if err = pkt.Read(reader); err != nil {
 		return nil, fmt.Errorf("could not decode packet data: %w", err)
 	}
 
-	return packet, nil
+	return pkt, nil
 }
 
 // WritePacket writes a Minecraft protocol packet to the connection.

--- a/connection.go
+++ b/connection.go
@@ -11,11 +11,14 @@ import (
 	"io"
 	"log"
 	"net"
+	"strconv"
 	"time"
 )
 
 const (
 	DefaultMinecraftPort = "25565"
+	MinecraftSRVService  = "minecraft"
+	MinecraftSRVProtocol = "tcp"
 )
 
 var (
@@ -29,64 +32,86 @@ var (
 type Connection interface {
 	ReadPacket(context.Context) (packet.Packet, error)
 	WritePacket(context.Context, packet.Packet) error
-	RemoteAddress() Address
 	Close() error
 	SetState(state types.ConnectionState)
 }
 
-type Address struct {
-	Host string
-	Port string
-}
-
 type connection struct {
-	remote    Address
 	transport net.Conn
 	state     types.ConnectionState
 	side      types.Side
 	packets   map[packet.PacketInfo]packet.Packet
 }
 
-// Dial connects to the specified address and creates
-// a new Connection for it.
-func Dial(host string, port string, side types.Side) (Connection, error) {
+// Dial connects to the specified address without timeout
+// and creates a new Connection for it. Returns the connection &
+// the address that was connected to.
+//
+// See DialContext for more information.
+func Dial(host string, port string, side types.Side) (Connection, string, error) {
 	return DialContext(context.Background(), host, port, side)
 }
 
-// Dial creates a TCP connection with specified host & port
-// and creates a new Connection for it. If the specified
-// port is an empty string, the Minecraft default of 25565 will be used.
+// DialContext creates a TCP connection with specified host & port
+// and creates a new Connection for it. If the specified port is
+// an empty string, the Minecraft default of 25565 will be used.
+//
+// Just like the vanilla Minecraft client, DialContext will do an SRV
+// DNS lookup before connecting to a Minecraft server with the default port.
+// If an SRV record is found, the contained target and port will be used
+// to connect instead.
 //
 // The provided Context must be non-nil. If the context expires before
 // the connection is complete, an error is returned. Once successfully
 // connected, any expiration of this context will not affect the connection.
-func DialContext(ctx context.Context, host string, port string, side types.Side) (Connection, error) {
+//
+// Will return the created Connection and the resolved address that
+// was connected to.
+func DialContext(ctx context.Context, host string, port string, side types.Side) (Connection, string, error) {
+	var resolver net.Resolver
+	var dialer net.Dialer
+
+	// If no port is given, use the default Minecraft port.
 	if port == "" {
 		port = DefaultMinecraftPort
 	}
 
-	// Make TCP connection
-	var d net.Dialer
-	tcpConn, err := d.DialContext(ctx, "tcp", net.JoinHostPort(host, port))
+	// If no port is given or the given port is the default,
+	// do a DNS SRV record lookup.
+	if port == DefaultMinecraftPort {
+		// Do DNS SRV record lookup on given hostname
+		_, srvRecords, err := resolver.LookupSRV(ctx, MinecraftSRVService, MinecraftSRVProtocol, host)
 
-	if err != nil {
-		return nil, err
+		if err == nil && len(srvRecords) > 0 {
+			// Override host & port with details from first SRV record returned
+			record := srvRecords[0]
+			host = record.Target
+			port = strconv.Itoa(int(record.Port))
+		}
 	}
 
-	return wrapConnection(tcpConn, Address{host, port}, side), nil
+	// Join host & port for connecting to the server but also for returning
+	// the resolved server address.
+	// Note: If the host was resolved via an SRV record, it will have a
+	// trailing period. This is kept so the returned address can be used for
+	// a handshake packet, which the vanilla client also sends with a trailing period.
+	resolvedAddress := net.JoinHostPort(host, port)
+
+	// Make TCP connection
+	tcpConn, err := dialer.DialContext(ctx, "tcp", resolvedAddress)
+
+	if err != nil {
+		return nil, resolvedAddress, err
+	}
+
+	// Wrap TCP connection in a wrapper for sending/receiving Minecraft packets
+	return WrapConnection(tcpConn, side), resolvedAddress, nil
 }
 
 // WrapConnection wraps the given connection with a Connection,
 // so it can be used for sending/receiving Minecraft packets.
 func WrapConnection(transport net.Conn, side types.Side) Connection {
-	// Ignoring error, conn remote address should always be valid
-	host, port, _ := net.SplitHostPort(transport.RemoteAddr().String())
-	return wrapConnection(transport, Address{host, port}, side)
-}
-
-func wrapConnection(transport net.Conn, addr Address, side types.Side) Connection {
 	conn := &connection{
-		remote:    addr,
 		transport: transport,
 		state:     types.ConnectionStateHandshake,
 		side:      side,
@@ -250,13 +275,6 @@ func (c *connection) WritePacket(ctx context.Context, packetToWrite packet.Packe
 // which changes the meaning of packet IDs.
 func (c *connection) SetState(state types.ConnectionState) {
 	c.state = state
-}
-
-// RemoteAddress returns the remote address of the connected
-// party. Can for instance be used to get the
-// resolved hostname & port of a minecraft server.
-func (c *connection) RemoteAddress() Address {
-	return c.remote
 }
 
 // Close closes the connection. After this has been called,

--- a/connection.go
+++ b/connection.go
@@ -48,8 +48,8 @@ type connection struct {
 // the address that was connected to.
 //
 // See DialContext for more information.
-func Dial(host string, port string, side types.Side) (Connection, string, error) {
-	return DialContext(context.Background(), host, port, side)
+func Dial(host string, port string) (Connection, string, error) {
+	return DialContext(context.Background(), host, port)
 }
 
 // DialContext creates a TCP connection with specified host & port
@@ -67,7 +67,7 @@ func Dial(host string, port string, side types.Side) (Connection, string, error)
 //
 // Will return the created Connection and the resolved address that
 // was connected to.
-func DialContext(ctx context.Context, host string, port string, side types.Side) (Connection, string, error) {
+func DialContext(ctx context.Context, host string, port string) (Connection, string, error) {
 	var resolver net.Resolver
 	var dialer net.Dialer
 
@@ -105,7 +105,7 @@ func DialContext(ctx context.Context, host string, port string, side types.Side)
 	}
 
 	// Wrap TCP connection in a wrapper for sending/receiving Minecraft packets
-	return WrapConnection(tcpConn, side), resolvedAddress, nil
+	return WrapConnection(tcpConn, types.ClientSide), resolvedAddress, nil
 }
 
 // WrapConnection wraps the given connection with a Connection,

--- a/examples/client/status/status.go
+++ b/examples/client/status/status.go
@@ -34,7 +34,7 @@ func main() {
 
 	ctx := context.Background()
 
-	conn, addr, err := mcproto.Dial(*ServerHost, *ServerPort, types.ClientSide)
+	conn, addr, err := mcproto.Dial(*ServerHost, *ServerPort)
 
 	if err != nil {
 		log.Fatalf("mcproto dial error: %s", err)

--- a/examples/client/status/status.go
+++ b/examples/client/status/status.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Raqbit/mcproto/packet"
 	"github.com/Raqbit/mcproto/types"
 	"log"
+	"net"
 	"os"
 	"strconv"
 )
@@ -33,14 +34,19 @@ func main() {
 
 	ctx := context.Background()
 
-	conn, err := mcproto.Dial(*ServerHost, *ServerPort, types.ClientSide)
+	conn, addr, err := mcproto.Dial(*ServerHost, *ServerPort, types.ClientSide)
 
 	if err != nil {
 		log.Fatalf("mcproto dial error: %s", err)
 	}
 
-	addr := conn.RemoteAddress()
-	port, err := strconv.Atoi(addr.Port)
+	host, portStr, err := net.SplitHostPort(addr)
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	port, err := strconv.Atoi(portStr)
 
 	if err != nil {
 		log.Fatal(err)
@@ -49,7 +55,7 @@ func main() {
 	err = conn.WritePacket(ctx,
 		&packet.HandshakePacket{
 			ProtoVer:   ProtocolVersion,
-			ServerAddr: enc.String(addr.Host),
+			ServerAddr: enc.String(host),
 			ServerPort: enc.UnsignedShort(port),
 			NextState:  types.ConnectionStateStatus,
 		})

--- a/examples/server/server.go
+++ b/examples/server/server.go
@@ -98,7 +98,7 @@ func handleLoginPacket(conn mcproto.Connection, v *packet.LoginStartPacket) erro
 		return fmt.Errorf("could not write login success packet: %w", err)
 	}
 
-	conn.SwitchState(types.ConnectionStatePlay)
+	conn.SetState(types.ConnectionStatePlay)
 
 	err = conn.WritePacket(context.Background(), &packet.JoinGamePacket{
 		PlayerID:            enc.Int(genRandomEid()),
@@ -194,12 +194,10 @@ func handleHandshakePacket(conn mcproto.Connection, p *packet.HandshakePacket) e
 		return fmt.Errorf("unsupported protocol version: %d", p.ProtoVer)
 	}
 
-	fmt.Println(p.NextState)
-
 	if p.NextState != types.ConnectionStateStatus && p.NextState != types.ConnectionStateLogin {
 		return fmt.Errorf("handshake packet with invalid next state")
 	} else {
-		conn.SwitchState(p.NextState)
+		conn.SetState(p.NextState)
 		return nil
 	}
 }

--- a/examples/server/server.go
+++ b/examples/server/server.go
@@ -57,7 +57,7 @@ func handleConnection(tcpConn net.Conn) {
 			}
 
 			log.Printf("Error reading packet: %s", err)
-			continue
+			return
 		}
 
 		err = handlePacket(conn, p)


### PR DESCRIPTION
- Changes the signature of `mcproto.Dial` to split the host & port. This was one `address` parameter before to match the tcp Dial function, but due to complexities in splitting host & port without making specifying a port mandatory (keeping compatibility with ipv4, ipv6 & hostnames) I decided to make them separate.
- mcproto will now do a DNS SRV record lookup before connecting with the default minecraft port (25565). The target & port of the first record returned will be used to connect to the server.
- mcproto will now default to port 25565 if an empty string is given.
- To allow the user to retrieve the resolved port for the handshake packet, `Dial` & `DialContext` will now return the resolved address which can be used to create the handshake packet. (See [example](https://github.com/Raqbit/mcproto/blob/aa03ee976bc1e5b70d6a30ef57a774816da6165e/examples/client/status/status.go#L43))