### PR TITLE
Change Dial signature to accept an address

### DIFF
--- a/examples/client/status/status.go
+++ b/examples/client/status/status.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"flag"
 	"fmt"
 	"github.com/Raqbit/mcproto"
 	enc "github.com/Raqbit/mcproto/encoding"
@@ -19,22 +18,16 @@ const (
 	ProtocolVersion = 578
 )
 
-var (
-	ServerHost = flag.String("host", "", "server host")
-	ServerPort = flag.String("port", "", "server port")
-)
-
 func main() {
-	flag.Parse()
 
-	if *ServerHost == "" {
-		flag.Usage()
+	if len(os.Args) != 2 {
+		fmt.Println("Please specify the address to get the status of")
 		os.Exit(2)
 	}
 
 	ctx := context.Background()
 
-	conn, addr, err := mcproto.Dial(*ServerHost, *ServerPort)
+	conn, addr, err := mcproto.DialContext(ctx, os.Args[1])
 
 	if err != nil {
 		log.Fatalf("mcproto dial error: %s", err)

--- a/util.go
+++ b/util.go
@@ -1,0 +1,94 @@
+package mcproto
+
+import (
+	"context"
+	"net"
+	"strconv"
+	"strings"
+)
+
+func ResolveServerAddress(ctx context.Context, address string) string {
+	var resolver net.Resolver
+
+	// Split host & port, port being optional
+	host, port := splitHostPort(address)
+
+	// If no port is given, use the default Minecraft port.
+	if port == "" {
+		port = DefaultMinecraftPort
+	}
+
+	// If no port is given or the given port is the default,
+	// do a DNS SRV record lookup.
+	if port == DefaultMinecraftPort {
+		// Do DNS SRV record lookup on given hostname
+		_, srvRecords, err := resolver.LookupSRV(ctx, MinecraftSRVService, MinecraftSRVProtocol, host)
+
+		if err == nil && len(srvRecords) > 0 {
+			// Override host & port with details from the first SRV record returned
+			record := srvRecords[0]
+			host = record.Target
+			port = strconv.Itoa(int(record.Port))
+		}
+	}
+
+	// Join host & port for connecting to the server but also for returning
+	// the resolved server address.
+	//
+	// Note: If the host was resolved via an SRV record, it will have a
+	// trailing period. This is kept so the returned address can be used for
+	// a handshake packet, which the vanilla client also sends with a trailing period.
+	return net.JoinHostPort(host, port)
+}
+
+// Like net.SplitHostPort but with the port being optional
+// Handles IPv6, IPv4 and hostnames
+func splitHostPort(address string) (host string, port string) {
+	// Ipv6 with port
+	if address[0] == '[' {
+		endIdx := strings.LastIndexByte(address, ']')
+		host = address[1:endIdx]
+		port = address[endIdx+2:]
+		return
+	}
+
+	lastColon := -1
+
+	i := len(address)
+	for i--; i >= 0; i-- {
+		if address[i] == ':' {
+			if lastColon != -1 {
+				// We found multiple colons, so ipv6 (without port)
+				host = address
+				return
+			}
+
+			lastColon = i
+		}
+
+		if address[i] == '.' {
+			// We found a dot, so we've found an ipv4 address or hostname
+			if lastColon != -1 {
+				// We found a port
+				host = address[0:lastColon]
+				port = address[lastColon+1:]
+			} else {
+				// We did not find a port
+				host = address
+			}
+			return
+		}
+	}
+
+	// Ipv4 or hostname without port
+	if lastColon == -1 {
+		host = address
+		return
+	}
+
+	// ipv4 or hostname with port
+	host = address[0:lastColon]
+	port = address[lastColon+1:]
+
+	return
+}

--- a/util_test.go
+++ b/util_test.go
@@ -1,0 +1,84 @@
+package mcproto
+
+import "testing"
+
+func Test_splitHostPort(t *testing.T) {
+	tests := []struct {
+		name     string
+		address  string
+		wantHost string
+		wantPort string
+	}{
+		{
+			name:     "ipv4",
+			address:  "127.0.0.1",
+			wantHost: "127.0.0.1",
+			wantPort: "",
+		},
+		{
+			name:     "ipv4_port",
+			address:  "127.0.0.1:25565",
+			wantHost: "127.0.0.1",
+			wantPort: "25565",
+		},
+		{
+			name:     "host_short",
+			address:  "localhost",
+			wantHost: "localhost",
+			wantPort: "",
+		},
+		{
+			name:     "host_short_port",
+			address:  "localhost:25565",
+			wantHost: "localhost",
+			wantPort: "25565",
+		},
+		{
+			name:     "host",
+			address:  "mc.raqb.it",
+			wantHost: "mc.raqb.it",
+			wantPort: "",
+		},
+		{
+			name:     "host_port",
+			address:  "mc.raqb.it:25565",
+			wantHost: "mc.raqb.it",
+			wantPort: "25565",
+		},
+		{
+			name:     "ipv6_short",
+			address:  "::1",
+			wantHost: "::1",
+			wantPort: "",
+		},
+		{
+			name:     "ipv6_short_port",
+			address:  "[::1]:25565",
+			wantHost: "::1",
+			wantPort: "25565",
+		},
+		{
+			name:     "ipv6",
+			address:  "c0ec:5d71:7830:511d:ae76:dbf0:d659:9754",
+			wantHost: "c0ec:5d71:7830:511d:ae76:dbf0:d659:9754",
+			wantPort: "",
+		},
+		{
+			name:     "ipv6_port",
+			address:  "[c0ec:5d71:7830:511d:ae76:dbf0:d659:9754]:25565",
+			wantHost: "c0ec:5d71:7830:511d:ae76:dbf0:d659:9754",
+			wantPort: "25565",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotHost, gotPort := splitHostPort(tt.address)
+			if gotHost != tt.wantHost {
+				t.Errorf("splitHostPort() gotHost = %v, want %v", gotHost, tt.wantHost)
+			}
+			if gotPort != tt.wantPort {
+				t.Errorf("splitHostPort() gotPort = %v, want %v", gotPort, tt.wantPort)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Currently `Dial` accepts a host and a port to connect to, while `net.Dial` simply accepts a single "address" parameter. 
This PR gives `Dial` such an `address` parameter and makes `Dial` parse the given address into a host & port, before doing SRV resolving and eventually connecting to the resolved server. The parsing works for hostnames, IPv4 and IPv6 addresses, both with and without ports.